### PR TITLE
lower case Filter in soap.js retrieve logic

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -24,272 +24,262 @@ module.exports = class Soap {
      * @returns {Promise<Object>} SOAP object converted from XML
      */
     retrieve(type, props, requestParams) {
-        const body = {
-            RetrieveRequestMsg: {
-                '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
-                RetrieveRequest: {
-                    ObjectType: type,
-                    Properties: props,
+            const body = {
+                RetrieveRequestMsg: {
+                    '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
+                    RetrieveRequest: {
+                        ObjectType: type,
+                        Properties: props,
+                    },
                 },
-            },
-        };
+            };
 
-        if (requestParams) {
-            validateOptions(requestParams.options, [
-                'BatchSize',
-                'IncludeObjects',
-                'OnlyIncludeBase',
-            ]);
-            if (requestParams.options) {
-                body.RetrieveRequestMsg.RetrieveRequest.Options = requestParams.options;
-            }
-            if (requestParams.ClientIDs) {
-                body.RetrieveRequestMsg.RetrieveRequest.ClientIDs = requestParams.clientIDs;
-            }
-            // filter can be simple or complex and has three properties leftOperand, rightOperand, and operator
-            if (requestParams.Filter) {
-                body.RetrieveRequestMsg.RetrieveRequest.Filter = _parseFilter(requestParams.filter);
-            }
-            if (requestParams.QueryAllAccounts) {
-                body.RetrieveRequestMsg.RetrieveRequest.QueryAllAccounts = true;
-            }
-            if (requestParams.continueRequest) {
-                body.RetrieveRequestMsg.RetrieveRequest.ContinueRequest =
-                    requestParams.continueRequest;
-            }
-        }
-
-        return _apiRequest(
-            this.auth,
-            {
-                action: 'Retrieve',
-                req: body,
-                key: 'RetrieveResponseMsg',
-            },
-            1
-        );
-    }
-    /**
-     * Method used to retrieve all data via SOAP API
-     * @param {string} type -SOAP Object type
-     * @param {Array<String>} props - Properties which should be retrieved
-     * @param {Object} [requestParams] - additional RetrieveRequest parameters, for example filter or options
-     * @returns {Promise<Object>} SOAP object converted from XML
-     */
-    async retrieveBulk(type, props, requestParams) {
-        let status;
-        let resultsBulk;
-        do {
-            const resultsBatch = await this.retrieve(type, props, requestParams);
-            if (resultsBulk) {
-                // once first batch is done, the follow just add to result payload
-                resultsBulk.Results.push(...resultsBatch.Results);
-            } else {
-                resultsBulk = resultsBatch;
-            }
-            status = resultsBatch.OverallStatus;
-            if (status === 'MoreDataAvailable') {
-                requestParams.continueRequest = resultsBatch.RequestID;
-                if (this.eventHandlers && this.eventHandlers.onLoop) {
-                    this.eventHandlers.onLoop(type, resultsBulk);
+            if (requestParams) {
+                validateOptions(requestParams.options, [
+                    'BatchSize',
+                    'IncludeObjects',
+                    'OnlyIncludeBase',
+                ]);
+                if (requestParams.options) {
+                    body.RetrieveRequestMsg.RetrieveRequest.Options = requestParams.options;
+                }
+                if (requestParams.ClientIDs) {
+                    body.RetrieveRequestMsg.RetrieveRequest.ClientIDs = requestParams.clientIDs;
+                }
+                // filter can be simple or complex and has three properties leftOperand, rightOperand, and operator
+                if (requestParams.filter) {
+                    body.RetrieveRequestMsg.RetrieveRequest.Filter = _parseFilter(requestParams.filter);
+                }
+                if (requestParams.QueryAllAccounts) {
+                    body.RetrieveRequestMsg.RetrieveRequest.QueryAllAccounts = true;
+                }
+                if (requestParams.continueRequest) {
+                    body.RetrieveRequestMsg.RetrieveRequest.ContinueRequest =
+                        requestParams.continueRequest;
                 }
             }
-        } while (status === 'MoreDataAvailable');
-        return resultsBulk;
-    }
-    /**
-     * Method used to create data via SOAP API
-     * @param {string} type -SOAP Object type
-     * @param {Array<String>} props - Properties which should be created
-     * @param {Object} options - configuration of the request
-     * @returns {Promise<Object>} SOAP object converted from XML
-     */
-    create(type, props, options) {
-        const body = {
-            CreateRequest: {
-                '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
-                Options: options,
-                Objects: props,
-            },
-        };
-        body.CreateRequest.Objects['@_xsi:type'] = type;
-        validateOptions(options);
-        return _apiRequest(
-            this.auth,
-            {
-                action: 'Create',
-                req: body,
-                key: 'CreateResponse',
-            },
-            1
-        );
-    }
-    /**
-     * Method used to update data via SOAP API
-     * @param {string} type -SOAP Object type
-     * @param {Array<String>} props - Properties which should be updated
-     * @param {Object} options - configuration of the request
-     * @returns {Promise<Object>} SOAP object converted from XML
-     */
-    update(type, props, options) {
-        const body = {
-            UpdateRequest: {
-                '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
-                Options: options,
-                Objects: props,
-            },
-        };
-        body.UpdateRequest.Objects['@_xsi:type'] = type;
-        validateOptions(options);
-        return _apiRequest(
-            this.auth,
-            {
-                action: 'Update',
-                req: body,
-                key: 'UpdateResponse',
-            },
-            1
-        );
-    }
-    /**
-     * Method used to delete data via SOAP API
-     * @param {string} type -SOAP Object type
-     * @param {Array<String>} props - Properties which should be retrieved
-     * @param {Object} options - configuration of the request
-     * @returns {Promise<Object>} SOAP object converted from XML
-     */
-    delete(type, props, options) {
-        const body = {
-            DeleteRequest: {
-                '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
-                Options: options,
-                Objects: props,
-            },
-        };
-        body.DeleteRequest.Objects['@_xsi:type'] = type;
-        validateOptions(options);
-        return _apiRequest(
-            this.auth,
-            {
-                action: 'Delete',
-                req: body,
-                key: 'DeleteResponse',
-            },
-            1
-        );
-    }
-    /**
-     * Method used to schedule data via SOAP API
-     * @param {string} type -SOAP Object type
-     * @param {Object} schedule -object for what the schedule should be
-     * @param {Array|Object} interactions - Object or array of interactions
-     * @param {string} action - type of schedul
-     * @param {Object} options - configuration of the request
-     * @returns {Promise<Object>} SOAP object converted from XML
-     */
-    schedule(type, schedule, interactions, action, options) {
-        const body = {
-            ScheduleRequestMsg: {
-                '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
-                Action: action,
-                Options: options,
-                Schedule: schedule,
-                Interactions: interactions,
-            },
-        };
-        if (Array.isArray(body.ScheduleRequestMsg.Interactions)) {
-            body.ScheduleRequestMsg.Interactions = body.ScheduleRequestMsg.Interactions.map((i) => {
-                i.Interaction['@_xsi:type'] = type;
-                return i;
-            });
-        } else if (isObject(body.ScheduleRequestMsg.Interactions)) {
-            body.ScheduleRequestMsg.Interactions.Interaction['@_xsi:type'] = type;
-        } else {
-            throw new TypeError('Interactions must be of Array or Object Type');
+
+            return _apiRequest(
+                this.auth, {
+                    action: 'Retrieve',
+                    req: body,
+                    key: 'RetrieveResponseMsg',
+                },
+                1
+            );
         }
-        validateOptions(options);
-        return _apiRequest(
-            this.auth,
-            {
-                action: 'Schedule',
-                req: body,
-                key: 'ScheduleResponse',
-            },
-            1
-        );
-    }
-    /**
-     * Method used to describe metadata via SOAP API
-     * @param {string} type -SOAP Object type
-     * @returns {Promise<Object>} SOAP object converted from XML
-     */
+        /**
+         * Method used to retrieve all data via SOAP API
+         * @param {string} type -SOAP Object type
+         * @param {Array<String>} props - Properties which should be retrieved
+         * @param {Object} [requestParams] - additional RetrieveRequest parameters, for example filter or options
+         * @returns {Promise<Object>} SOAP object converted from XML
+         */
+    async retrieveBulk(type, props, requestParams) {
+            let status;
+            let resultsBulk;
+            do {
+                const resultsBatch = await this.retrieve(type, props, requestParams);
+                if (resultsBulk) {
+                    // once first batch is done, the follow just add to result payload
+                    resultsBulk.Results.push(...resultsBatch.Results);
+                } else {
+                    resultsBulk = resultsBatch;
+                }
+                status = resultsBatch.OverallStatus;
+                if (status === 'MoreDataAvailable') {
+                    requestParams.continueRequest = resultsBatch.RequestID;
+                    if (this.eventHandlers && this.eventHandlers.onLoop) {
+                        this.eventHandlers.onLoop(type, resultsBulk);
+                    }
+                }
+            } while (status === 'MoreDataAvailable');
+            return resultsBulk;
+        }
+        /**
+         * Method used to create data via SOAP API
+         * @param {string} type -SOAP Object type
+         * @param {Array<String>} props - Properties which should be created
+         * @param {Object} options - configuration of the request
+         * @returns {Promise<Object>} SOAP object converted from XML
+         */
+    create(type, props, options) {
+            const body = {
+                CreateRequest: {
+                    '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
+                    Options: options,
+                    Objects: props,
+                },
+            };
+            body.CreateRequest.Objects['@_xsi:type'] = type;
+            validateOptions(options);
+            return _apiRequest(
+                this.auth, {
+                    action: 'Create',
+                    req: body,
+                    key: 'CreateResponse',
+                },
+                1
+            );
+        }
+        /**
+         * Method used to update data via SOAP API
+         * @param {string} type -SOAP Object type
+         * @param {Array<String>} props - Properties which should be updated
+         * @param {Object} options - configuration of the request
+         * @returns {Promise<Object>} SOAP object converted from XML
+         */
+    update(type, props, options) {
+            const body = {
+                UpdateRequest: {
+                    '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
+                    Options: options,
+                    Objects: props,
+                },
+            };
+            body.UpdateRequest.Objects['@_xsi:type'] = type;
+            validateOptions(options);
+            return _apiRequest(
+                this.auth, {
+                    action: 'Update',
+                    req: body,
+                    key: 'UpdateResponse',
+                },
+                1
+            );
+        }
+        /**
+         * Method used to delete data via SOAP API
+         * @param {string} type -SOAP Object type
+         * @param {Array<String>} props - Properties which should be retrieved
+         * @param {Object} options - configuration of the request
+         * @returns {Promise<Object>} SOAP object converted from XML
+         */
+    delete(type, props, options) {
+            const body = {
+                DeleteRequest: {
+                    '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
+                    Options: options,
+                    Objects: props,
+                },
+            };
+            body.DeleteRequest.Objects['@_xsi:type'] = type;
+            validateOptions(options);
+            return _apiRequest(
+                this.auth, {
+                    action: 'Delete',
+                    req: body,
+                    key: 'DeleteResponse',
+                },
+                1
+            );
+        }
+        /**
+         * Method used to schedule data via SOAP API
+         * @param {string} type -SOAP Object type
+         * @param {Object} schedule -object for what the schedule should be
+         * @param {Array|Object} interactions - Object or array of interactions
+         * @param {string} action - type of schedul
+         * @param {Object} options - configuration of the request
+         * @returns {Promise<Object>} SOAP object converted from XML
+         */
+    schedule(type, schedule, interactions, action, options) {
+            const body = {
+                ScheduleRequestMsg: {
+                    '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
+                    Action: action,
+                    Options: options,
+                    Schedule: schedule,
+                    Interactions: interactions,
+                },
+            };
+            if (Array.isArray(body.ScheduleRequestMsg.Interactions)) {
+                body.ScheduleRequestMsg.Interactions = body.ScheduleRequestMsg.Interactions.map((i) => {
+                    i.Interaction['@_xsi:type'] = type;
+                    return i;
+                });
+            } else if (isObject(body.ScheduleRequestMsg.Interactions)) {
+                body.ScheduleRequestMsg.Interactions.Interaction['@_xsi:type'] = type;
+            } else {
+                throw new TypeError('Interactions must be of Array or Object Type');
+            }
+            validateOptions(options);
+            return _apiRequest(
+                this.auth, {
+                    action: 'Schedule',
+                    req: body,
+                    key: 'ScheduleResponse',
+                },
+                1
+            );
+        }
+        /**
+         * Method used to describe metadata via SOAP API
+         * @param {string} type -SOAP Object type
+         * @returns {Promise<Object>} SOAP object converted from XML
+         */
     describe(type) {
-        return _apiRequest(
-            this.auth,
-            {
-                action: 'Describe',
-                req: {
-                    DefinitionRequestMsg: {
-                        '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
-                        DescribeRequests: {
-                            ObjectDefinitionRequest: {
-                                ObjectType: type,
+            return _apiRequest(
+                this.auth, {
+                    action: 'Describe',
+                    req: {
+                        DefinitionRequestMsg: {
+                            '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
+                            DescribeRequests: {
+                                ObjectDefinitionRequest: {
+                                    ObjectType: type,
+                                },
                             },
                         },
                     },
+                    key: 'DefinitionResponseMsg',
                 },
-                key: 'DefinitionResponseMsg',
-            },
-            1
-        );
-    }
-    /**
-     * Method used to execute data via SOAP API
-     * @param {string} type -SOAP Object type
-     * @param {Array<String>} props - Properties which should be retrieved
-     * @returns {Promise<Object>} SOAP object converted from XML
-     */
+                1
+            );
+        }
+        /**
+         * Method used to execute data via SOAP API
+         * @param {string} type -SOAP Object type
+         * @param {Array<String>} props - Properties which should be retrieved
+         * @returns {Promise<Object>} SOAP object converted from XML
+         */
     execute(type, props) {
-        return _apiRequest(
-            this.auth,
-            {
-                action: 'Execute',
-                req: {
-                    ExecuteRequestMsg: {
-                        '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
-                        Requests: {
-                            Name: type,
-                            Parameters: props,
+            return _apiRequest(
+                this.auth, {
+                    action: 'Execute',
+                    req: {
+                        ExecuteRequestMsg: {
+                            '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
+                            Requests: {
+                                Name: type,
+                                Parameters: props,
+                            },
                         },
                     },
+                    key: 'ExecuteResponseMsg',
                 },
-                key: 'ExecuteResponseMsg',
-            },
-            1
-        );
-    }
-    /**
-     * Method used to execute data via SOAP API
-     * @param {string} type -SOAP Object type
-     * @param {Array<String>} props - Properties which should be retrieved
-     * @returns {Promise<Object>} SOAP object converted from XML
-     */
+                1
+            );
+        }
+        /**
+         * Method used to execute data via SOAP API
+         * @param {string} type -SOAP Object type
+         * @param {Array<String>} props - Properties which should be retrieved
+         * @returns {Promise<Object>} SOAP object converted from XML
+         */
     perform(type) {
         return _apiRequest(
-            this.auth,
-            {
+            this.auth, {
                 action: 'perform',
                 req: {
                     PerformRequestMsg: {
                         '@_xmlns': 'http://exacttarget.com/wsdl/partnerAPI',
                         Action: 'start',
-                        Definitions: [
-                            {
-                                Definition: {
-                                    '@_xsi:type': type,
-                                },
+                        Definitions: [{
+                            Definition: {
+                                '@_xsi:type': type,
                             },
-                        ],
+                        }, ],
                     },
                 },
                 key: 'PerformResponseMsg',
@@ -404,9 +394,9 @@ async function _parseResponse(body, key) {
             return soapBody[key];
         } else {
             // This is an error
-            const errorType = soapBody[key].OverallStatus.includes(':')
-                ? soapBody[key].OverallStatus.split(':')[1].trim()
-                : soapBody[key].OverallStatus;
+            const errorType = soapBody[key].OverallStatus.includes(':') ?
+                soapBody[key].OverallStatus.split(':')[1].trim() :
+                soapBody[key].OverallStatus;
             const soapError = new Error(errorType);
             soapError.requestId = soapBody[key].RequestID;
             soapError.errorPropagatedFrom = key;


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

- [ ] Documentation update
- [ X] Bug fix
- [ ] New metadata support
- [ ] Enhanced metadata
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

## What changes did you make? (Give an overview)

When using the soap client retrieve, using a filter object as described below doesn't work as expected. There is logic set to look for `requestParams.Filter` and the expected key for the filter object is `filter`. To get the filter to be recognized, I had to include `Filter: true, filter: {...}`

Did not work:
`{
   filter: {
        leftOperand: 'DataExtension.CustomerKey',
        operator: 'equals',
         rightOperand: loggingDE
}
`

Works:
`{
  Filter: true,
   filter: {
        leftOperand: 'DataExtension.CustomerKey',
        operator: 'equals',
         rightOperand: loggingDE
}
`

## Is there anything you'd like reviewers to focus on?

...
