### PR TITLE
#150: ensure rest API errors print the targeted endpoint

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -203,7 +203,7 @@ module.exports = class Rest {
                 //only retry once on refresh since there should be no reason for this token to be invalid
                 return this._apiRequest(requestOptions, 1);
             } else {
-                throw new RestError(ex);
+                throw new RestError(ex, requestOptions.baseURL + requestOptions.url);
             }
         }
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,7 +31,7 @@ module.exports.isConnectionError = (code) =>
  * @augments {Error}
  */
 module.exports.RestError = class RestError extends Error {
-    constructor(ex) {
+    constructor(ex, url) {
         // Expired Error
         if (ex.response?.data?.message) {
             super(ex.response.data.message);
@@ -44,6 +44,10 @@ module.exports.RestError = class RestError extends Error {
         } else {
             super(ex.message);
             this.code = ex.code;
+        }
+        if (url) {
+            this.endpoint = url;
+            this.message += ` (endpoint: ${this.endpoint})`;
         }
         this.response = ex.response;
         this.name = this.constructor.name;

--- a/lib/util.js
+++ b/lib/util.js
@@ -47,7 +47,6 @@ module.exports.RestError = class RestError extends Error {
         }
         if (url) {
             this.endpoint = url;
-            this.message += ` (endpoint: ${this.endpoint})`;
         }
         this.response = ex.response;
         this.name = this.constructor.name;


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)


-   [x] Improvements


## What changes did you make? (Give an overview)

- closes #150 

basically ensures we can actually call support when the rest API returns such an error because now we can tell them which endpoint we tried.

added the endpoint as a separate attribute as well as directly inside of the main rest-error message due to its importance
