### PR TITLE
#167: always attach "endpoint" to errors thrown in rest.js

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -191,6 +191,13 @@ module.exports = class Rest {
             }
             return response.data;
         } catch (ex) {
+            if (requestOptions.url) {
+                ex.endpoint =
+                    requestOptions.baseURL +
+                    (requestOptions.url.startsWith('/')
+                        ? requestOptions.url.slice(1)
+                        : requestOptions.url);
+            }
             if (
                 this.options.retryOnConnectionError &&
                 remainingAttempts > 0 &&
@@ -206,7 +213,7 @@ module.exports = class Rest {
                 //only retry once on refresh since there should be no reason for this token to be invalid
                 return this._apiRequest(requestOptions, 1);
             } else {
-                throw new RestError(ex, requestOptions.baseURL + requestOptions.url);
+                throw new RestError(ex);
             }
         }
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,7 +31,7 @@ module.exports.isConnectionError = (code) =>
  * @augments {Error}
  */
 module.exports.RestError = class RestError extends Error {
-    constructor(ex, url) {
+    constructor(ex) {
         // Expired Error
         if (ex.response?.data?.message) {
             super(ex.response.data.message);
@@ -45,8 +45,8 @@ module.exports.RestError = class RestError extends Error {
             super(ex.message);
             this.code = ex.code;
         }
-        if (url) {
-            this.endpoint = url;
+        if (ex.endpoint) {
+            this.endpoint = ex.endpoint;
         }
         this.response = ex.response;
         this.name = this.constructor.name;


### PR DESCRIPTION
# PR details

## What is the purpose of this pull request? (put an "X" next to an item)

-   [ ] Fix
-   [x] Improvements
-   [ ] New Feature
-   [ ] Documentation updates
-   [ ] Other, please explain:

## What changes did you make? (Give an overview)

- closes #167 

before, only RestErrors would have the new "endpoint" attribute. but rest.js throws generic errors as well which should include this value for further processing.